### PR TITLE
Add Support for importing into Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ If this library should not work at some point, please create an issue and let me
 `npm install yt-comment-scraper`
 
 ##Usage
-`const ytcomments = require("yt-comment-scraper")`
+```javascript
+const CommentScraper = require("yt-comment-scraper")
+
+const ytcomments = new CommentsScraper() // A boolean can optionally be passed to determine if cookies should be set or not when requests are made.
+```
 
 ## API
 **scrape_all_youtube_comments(videoId)**
@@ -59,4 +63,4 @@ Everything is a string because the given format is string and then everyone can 
 }
 ```
 ## Credits
-Thanks to egbertbouman for his/her Python [project](https://github.com/egbertbouman/youtube-comment-downloader) which guided this project through the difficult HTTP calls. 
+Thanks to egbertbouman for his/her Python [project](https://github.com/egbertbouman/youtube-comment-downloader) which guided this project through the difficult HTTP calls.

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-//module.exports = require("./src/Youtube-Scraper")
+module.exports = require("./src/Youtube-Scraper")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-comment-scraper",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-comment-scraper",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Accesses the comments of YouTube via an Ajax call towards YouTube after initially accessing the video page.",
   "main": "index.js",
   "scripts": {

--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -3,8 +3,12 @@ const baseURL = "https://www.youtube.com/"
 const ajaxURL = "comment_ajax"
 
 class HttpRequester {
-    static session;
-    static async requestVideoPage(videoId) {
+    constructor(setCookie) {
+      this.session = null
+      this.setCookie = setCookie
+    }
+
+    async requestVideoPage(videoId) {
         //'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
         this.session = axios.create({
             baseURL: baseURL,
@@ -24,9 +28,13 @@ class HttpRequester {
         // cookie1 = GPS=1; path=/; domain=.youtube.com; expires=Thu, 17-Sep-2020 13:03:47 GMT  cookie2 = VISITOR_INFO1_LIVE=a9IsI_YF_U8; path=/; domain=.youtube.com; secure; expires=Tue, 16-Mar-2021 12:33:47 GMT; httponly; samesite=None
         try {
             const response =  await axios.get(baseURL+ "watch?v=" + videoId)
-            this.session.defaults.headers.Cookie = response.headers["set-cookie"][0]
-            //this.session.defaults.headers.Cookie = (response.headers["set-cookie"][1])
-            this.session.defaults.headers.Cookie = response.headers["set-cookie"][0]+';'+response.headers["set-cookie"][1]+';'+response.headers["set-cookie"][2]
+
+            if (this.setCookie) {
+              this.session.defaults.headers.Cookie = response.headers["set-cookie"][0]
+              //this.session.defaults.headers.Cookie = (response.headers["set-cookie"][1])
+              this.session.defaults.headers.Cookie = response.headers["set-cookie"][0]+';'+response.headers["set-cookie"][1]+';'+response.headers["set-cookie"][2]
+            }
+
             return response
             //return await axios.get(trending_page, config)
         } catch (e) {
@@ -36,7 +44,7 @@ class HttpRequester {
             }
         }
     }
-    static async ajax_request(data, params){
+    async ajax_request(data, params){
         // this params variable is needed in order to post the data as raw body and not as object
         const urlSearchParams = new URLSearchParams();
         urlSearchParams.append('video_id', data.video_id)
@@ -48,7 +56,7 @@ class HttpRequester {
         //return this.session.post('http://requestbin.net/r/1dt35v81' + `?action_load_comments=1&order_by_time=true&filter=${params.filter}&order_menu=${params.order_menu}`, urlSearchParams)
         return this.session.post(ajaxURL + `?action_load_comments=1&order_by_time=True&filter=${params.filter}&order_menu=${params.order_menu}`, urlSearchParams)
     }
-    static deleteSession(){
+    deleteSession(){
         this.session = null
     }
 }


### PR DESCRIPTION
This PR updates the package to allow importing into Electron based apps.  The biggest issues were the static variables / functions along with the cookies that were being set.  These cookies aren't needed in Electron so a constructor was created to allow the developer to specify if they want the cookies to be set.  Setting it to true allows it to be used in Node / CLI environments while `false` allows it to be used in Electron environments.  I've tested this on FreeTube as well and seems to be working just fine.  The static variables were moved to the constructor and the functions had their static types removed.