### PR TITLE
Update to New Comments API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # YouTube Comment Scraper NodeJS Documentation
-This NodeJS library scrapes the comments of the YouTube provided HTML comment data without any API usage order by date descending (so most recent first). It is developed for and tailored towards easy usage in the [FreeTube](https://github.com/FreeTubeApp/FreeTube) rewrite but can be used with any other project as well.
-The library is able to scrape all comments at once or scrape only one page at a time and allowing follow-up pages to be loaded later. When performance is an issue, it is advised to use the page by page loading, because then data is only loaded when needed.
+This NodeJS library scrapes the comments of the YouTube provided HTML comment data without any API usage order by date descending (so most recent first). It is developed for and tailored towards easy usage with [FreeTube](https://github.com/FreeTubeApp/FreeTube) but can be used with any other project as well.
 
-Therefore, this library does not require any API keys, with the attached maximum quotas, but instead might take longer to receive the required data.
+This library does not require any API keys, with the attached maximum quotas, but instead might take longer to receive the required data.
 
 The library works as long as YouTube keeps its web page layout the same. Therefore, there is **no guarantee** that this library will work at all times.
 If this library should not work at some point, please create an issue and let me know so that I can take a look into it. Pull requests are also welcomed in this case.
@@ -20,33 +19,14 @@ const ytcm = require("yt-comment-scraper")
 import ytcm from 'yt-comment-scraper'
 ```
 
-## API
-**getAllComments(videoId, sortByNewest, setCookie)**
-
-Returns a list of objects containing **all** comments and replies of the video.
-
-- videoId (String) (Required) - The video ID to get comments from
-- sortByNewest (Boolean) (Default: false) - Whether to sort by the newest comments or to sort by the top comments.
-- setCookie (Boolean) (Default: true) - Whether to set cookies while grabbing comments or not. Sometimes needs to be `false` depending on your environment
-
-**WARNING:** This command can take a _long_ time to run depending on the amount of comments being grabbed. Be aware that this might be very resourse heavy and you may want to use `getComments()` instead to paginate through comments.
-
-```javascript
-ytcm.getAllComments(videoId, sortByNewest, setCookie).then((data) =>{
-    console.log(data);
-}).catch((error)=>{
-    console.log(error);
-});
-```
 **getComments(payload)**
 
-Returns a list of objects containing comments and replies from the next page of the video.
+Returns a list of objects containing comments from the next page of the video.
 
 - payload (Object) (Required) - An object containing the various options
   - videoId (String) (Required) - The video ID to grab comments from
   - sortByNewest (Boolean) (Default: `false`) - Grabs newest comments when `true`. Grabs top comments when `false`
   - setCookie (Boolean) (Default: `true`) - Sets a cookie internally when grabbing comments. May not be needed depending on your environment
-  - xsrf (String) (Optional) - The XSRF token needed to grab comments from a video. Module will automatically grab this token if not provided
   - continuation (Optional) - The token from a previous call to continue grabbing comments
 
 ```javascript
@@ -54,7 +34,6 @@ const payload = {
   videoId: videoId, // Required
   sortByNewest: sortByNewest,
   setCookie: setCookie,
-  xsrf: xsrf,
   continuation: continuation
 }
 
@@ -70,18 +49,64 @@ The data is returned as a list of objects (seen below). The replies have the sam
 ```javascript
 // The data is a list of objects containing the following attributes:
 {
-  id: commentId,
-  author: authorName,
-  authorLink: authorChannelUrl,
-  authorThumb: authorChannelPicture,
-  edited: wasItEdited (true/false)
-  text: commentText,
-  likes: numberOfDisplayedUpvotes,
-  time: publishedText (in english: '1 year'),
-  hasReplies: hasReplies,
-  numReplies: numberOfReplies,
-  isHearted: true/false,
-  replies: [replyObjects]
+  commentId: String, // Id of comment
+  authorId: String, // Id of user that made the comment
+  author: String, // Name of the channel that made the comment
+  authorThumb: Array [ // An Array of thumbnails of the channel profile
+    {
+      width: Number,
+      height: Number,
+      url: String
+    }
+  ],
+  edited: Boolean, // If the comment has been edited or not
+  text: String, // The text content of the comment
+  likes: Number, // The amount of likes the comment has
+  time: String, // The time the comment was published. Written as "One day ago"
+  numReplies: Number, // The number of replies found for the comment
+  isHearted: Boolean, // If the video channel hearted the comment
+  replyToken: String // The continuation token needed for getCommentReplies()
+}
+```
+
+**getCommentReplies(videoId, continuation)**
+
+Returns a list of objects containing replies from a given comment.
+
+- payload (Object) (Required) - An object containing the various options
+  - videoId (String) (Required) - The video ID to grab comments from
+  - continuation (String) (Required) - The reply token from a comment
+
+```javascript
+ytcm.getCommentReplies(videoId, continuation).then((data) =>{
+    console.log(data);
+}).catch((error)=>{
+    console.log(error);
+});
+```
+**Returned Data**
+
+The data is returned as a list of objects (seen below). The replies have the same structure, except they are missing the replies attribute.
+```javascript
+// The data is a list of objects containing the following attributes:
+{
+  commentId: String, // Id of comment
+  authorId: String, // Id of user that made the comment
+  author: String, // Name of the channel that made the comment
+  authorThumb: Array [ // An Array of thumbnails of the channel profile
+    {
+      width: Number,
+      height: Number,
+      url: String
+    }
+  ],
+  edited: Boolean, // If the comment has been edited or not
+  text: String, // The text content of the comment
+  likes: Number, // The amount of likes the comment has
+  time: String, // The time the comment was published. Written as "One day ago"
+  numReplies: Number, // The number of replies found for the comment, always 0
+  isHearted: Boolean, // If the video channel hearted the comment, always false
+  replyToken: String // The continuation token needed for getCommentReplies(), Always null
 }
 ```
 ## Credits

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ If this library should not work at some point, please create an issue and let me
 ## Installation
 `npm install yt-comment-scraper --save`
 
-##Usage
-Create a new instance of the comment scraper with optional parameters. The first one (default = true) sets the module cookie if the module has to handle the cookies itself.
-Set the value to false if you use something like Electron, which handles cookies by itself.
-The second variable changes the sorting mode of the comments from popular (default = false) to newest (true)
+## Usage
+Set your instance with the following syntax. Use the second line instead if you're using modules / Typescript
 ```javascript
 const ytcm = require("yt-comment-scraper")
 
@@ -48,25 +46,27 @@ ytcm.getComments(payload).then((data) =>{
 The data is returned as a list of objects (seen below). The replies have the same structure, except they are missing the replies attribute.
 ```javascript
 // The data is a list of objects containing the following attributes:
-{
-  commentId: String, // Id of comment
-  authorId: String, // Id of user that made the comment
-  author: String, // Name of the channel that made the comment
-  authorThumb: Array [ // An Array of thumbnails of the channel profile
-    {
-      width: Number,
-      height: Number,
-      url: String
-    }
-  ],
-  edited: Boolean, // If the comment has been edited or not
-  text: String, // The text content of the comment
-  likes: Number, // The amount of likes the comment has
-  time: String, // The time the comment was published. Written as "One day ago"
-  numReplies: Number, // The number of replies found for the comment
-  isHearted: Boolean, // If the video channel hearted the comment
-  replyToken: String // The continuation token needed for getCommentReplies()
-}
+  comments: [
+  {
+    commentId: String, // Id of comment
+    authorId: String, // Id of user that made the comment
+    author: String, // Name of the channel that made the comment
+    authorThumb: Array [ // An Array of thumbnails of the channel profile
+      {
+        width: Number,
+        height: Number,
+        url: String
+      }
+    ],
+    edited: Boolean, // If the comment has been edited or not
+    text: String, // The text content of the comment
+    likes: Number, // The amount of likes the comment has
+    time: String, // The time the comment was published. Written as "One day ago"
+    numReplies: Number, // The number of replies found for the comment
+    isHearted: Boolean, // If the video channel hearted the comment
+    replyToken: String // The continuation token needed for getCommentReplies()
+  }],
+  continuation: String // The continuation token needed to get more replies from getComments()
 ```
 
 **getCommentReplies(videoId, continuation)**
@@ -89,25 +89,27 @@ ytcm.getCommentReplies(videoId, continuation).then((data) =>{
 The data is returned as a list of objects (seen below). The replies have the same structure, except they are missing the replies attribute.
 ```javascript
 // The data is a list of objects containing the following attributes:
-{
-  commentId: String, // Id of comment
-  authorId: String, // Id of user that made the comment
-  author: String, // Name of the channel that made the comment
-  authorThumb: Array [ // An Array of thumbnails of the channel profile
-    {
-      width: Number,
-      height: Number,
-      url: String
-    }
-  ],
-  edited: Boolean, // If the comment has been edited or not
-  text: String, // The text content of the comment
-  likes: Number, // The amount of likes the comment has
-  time: String, // The time the comment was published. Written as "One day ago"
-  numReplies: Number, // The number of replies found for the comment, always 0
-  isHearted: Boolean, // If the video channel hearted the comment, always false
-  replyToken: String // The continuation token needed for getCommentReplies(), Always null
-}
+  comments: [
+  {
+    commentId: String, // Id of comment
+    authorId: String, // Id of user that made the comment
+    author: String, // Name of the channel that made the comment
+    authorThumb: Array [ // An Array of thumbnails of the channel profile
+      {
+        width: Number,
+        height: Number,
+        url: String
+      }
+    ],
+    edited: Boolean, // If the comment has been edited or not
+    text: String, // The text content of the comment
+    likes: Number, // The amount of likes the comment has
+    time: String, // The time the comment was published. Written as "One day ago"
+    numReplies: Number, // The number of replies found for the comment
+    isHearted: Boolean, // If the video channel hearted the comment
+    replyToken: String // The continuation token needed for getCommentReplies()
+  }],
+  continuation: String // The continuation token needed to get more replies from getComments()
 ```
 ## Credits
 Thanks to egbertbouman for his/her Python [project](https://github.com/egbertbouman/youtube-comment-downloader) which guided this project through the difficult HTTP calls.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-comment-scraper",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Scrapes the comments of any YouTube video without YouTube API access. Uses the default YouTube Ajax calls to get the comment data.",
   "main": "index.js",
   "scripts": {

--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -1,25 +1,44 @@
 const axios = require("axios")
 const baseURL = "https://www.youtube.com/"
-const ajaxURL = "comment_ajax"
+const ajaxURL = "comment_service_ajax"
 
 class HttpRequester {
-    async getXsrfToken(videoId, setCookie=true) {
+    async getVideoTokens(videoId, sortBy='top', setCookie=true) {
       // cookie1 = GPS=1; path=/; domain=.youtube.com; expires=Thu, 17-Sep-2020 13:03:47 GMT  cookie2 = VISITOR_INFO1_LIVE=a9IsI_YF_U8; path=/; domain=.youtube.com; secure; expires=Tue, 16-Mar-2021 12:33:47 GMT; httponly; samesite=None
       this.session = axios.create({
           baseURL: baseURL,
           timeout: 10000,
           headers: {
-              'accept-language': 'en-US,en;q=0.5'
+            'X-YouTube-Client-Name': '1',
+            'X-YouTube-Client-Version': '2.20201202.06.01',
+            'accept-language': 'en-US,en;q=0.5'
           }
       })
       try {
           const response =  await axios.get(baseURL+ "watch?v=" + videoId)
           const html_data = response.data
-
           const pre_token = html_data.match(/"XSRF_TOKEN":"[^"]*"/)[0]
+
           // token embedded in page, needed for ajax request
           let xsrf = pre_token.substring(14, pre_token.length-1)
           xsrf = xsrf.replace(/\\u003d/g, "=")
+
+          let continuation = html_data.match(/"nextContinuationData":{"continuation":"(.*?)}/)[0]
+          continuation = JSON.parse(`{${continuation}}`)
+
+          let serializedShareEntity = html_data.match(/"serializedShareEntity":(.*?)}/)[0]
+          serializedShareEntity = JSON.parse(`{${serializedShareEntity}`)
+
+          let serializedToken = serializedShareEntity.serializedShareEntity.replace(/\w%3D%3D/, '')
+          serializedToken = serializedToken.replace(/C{1}/, '')
+
+          let continuationToken = continuation.nextContinuationData.continuation
+
+          if (sortBy === 'new') {
+            continuationToken = continuationToken.replace('%3D', '') + `yFSIRI${serializedToken}TABeAIwAA%3D%3D`
+          }
+
+          // const clickTrackingParams = continuation.nextContinuationData.clickTrackingParams
 
           if (setCookie) {
             this.cookie1 = response.headers["set-cookie"][0]
@@ -27,7 +46,12 @@ class HttpRequester {
             this.cookie2 = response.headers["set-cookie"][0]+';'+response.headers["set-cookie"][1]+';'+response.headers["set-cookie"][2]
           }
 
-          return xsrf
+          const returnData = {
+            xsrf: xsrf,
+            continuation: continuationToken
+          }
+
+          return returnData
       } catch (e) {
           return {
               error: true,
@@ -37,35 +61,26 @@ class HttpRequester {
     }
 
     async requestCommentsPage(payload){
-
-        this.session = axios.create({
-            baseURL: baseURL,
-            timeout: 10000,
-            headers: {
-                'accept-language': 'en-US,en;q=0.5'
-            }
-        })
-
         if (this.cookie1 && this.cookie2) {
           this.session.defaults.headers.Cookie = this.cookie1
           this.session.defaults.headers.Cookie = this.cookie2
         }
 
-        const config = {
-            headers: {
-                'x-youtube-client-name': '1',
-                'x-youtube-client-version': '2.20180222',
-                'accept-language': 'en-US,en;q=0.5'
-            }
-        }
-
         // this params variable is needed in order to post the data as raw body and not as object
         const urlSearchParams = new URLSearchParams();
-        urlSearchParams.append('video_id', payload.videoId)
+        // urlSearchParams.append('video_id', payload.videoId)
         urlSearchParams.append('session_token', payload.session_token)
-        urlSearchParams.append('page_token', payload.page_token)
+        // urlSearchParams.append('page_token', payload.page_token)
 
-        return await this.session.post(ajaxURL + `?action_load_comments=1&order_by_time=${payload.order_by_time}&filter=${payload.filter}&order_menu=${payload.order_menu}`, urlSearchParams)
+        let urlParams
+
+        if (payload.useReplyEndpoint) {
+          urlParams = `?action_get_comment_replies=1&pbj=1&ctoken=${payload.page_token}&continuation=${payload.page_token}`
+        } else {
+          urlParams = `?action_get_comments=1&pbj=1&ctoken=${payload.page_token}&continuation=${payload.page_token}`
+        }
+
+        return await this.session.post(ajaxURL + urlParams, urlSearchParams)
     }
 }
 module.exports = HttpRequester

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -2,65 +2,65 @@ const parser = require('node-html-parser')
 
 class HtmlParser {
 
-  static parseHtmlData(data) {
-    const root = parser.parse(data)
+  static parseCommentData(data) {
     const comments = []
-    const nodes = this.removeTextNodes(root.childNodes)
 
-    nodes.forEach((node) => {
-      const commentEntryNode = this.removeTextNodes(node.childNodes)
-      const commentContentNode = this.removeTextNodes(commentEntryNode[0].childNodes)
-      const repliesNode = this.removeTextNodes(commentEntryNode[1].childNodes)
-      const commentObject = this.parseComment(commentContentNode)
-      commentObject.hasReplies = repliesNode ? true : false
-      commentObject.numReplies = repliesNode ? repliesNode.length : 0
-      commentObject.replies = this.parseReplies(repliesNode)
-      comments.push(commentObject)
+    data.forEach((node) => {
+      const comment = node.commentThreadRenderer ? node.commentThreadRenderer.comment.commentRenderer : node.commentRenderer
+      let replies = null
+      let text = ''
+      let isHearted = false
+
+      const commentId = comment.commentId
+      const authorId = comment.authorEndpoint.browseEndpoint.browseId
+      const authorName = comment.authorText.simpleText
+      const authorThumbnails = comment.authorThumbnail.thumbnails
+      const likes = comment.likeCount
+      const numReplies = comment.replyCount ? comment.replyCount : 0
+      const publishedTimeText = comment.publishedTimeText.runs[0].text
+      const publishedText = publishedTimeText.replace('(edited)', '').trim()
+      const isEdited = publishedTimeText.includes('edited')
+
+      const heartBadge = comment.actionButtons.commentActionButtonsRenderer.creatorHeart
+
+      if (typeof heartBadge !== 'undefined') {
+        isHearted = heartBadge.creatorHeartRenderer.isHearted
+      }
+
+      const contentText = comment.contentText.runs
+
+      contentText.forEach((content) => {
+        if (content.text.trim() === '') {
+          text = text + '<br>'
+        } else {
+          text = text + content.text
+        }
+      })
+
+      const object = {
+        authorThumb: authorThumbnails,
+        author: authorName,
+        authorId: authorId,
+        commentId: commentId,
+        text: text,
+        likes: likes,
+        numReplies: numReplies,
+        isHearted: isHearted,
+        time: publishedText,
+        edited: isEdited,
+        replyToken: null
+      }
+
+      if (comment.replyCount > 0) {
+        const replyNode = node.commentThreadRenderer.replies.commentRepliesRenderer
+        const continuation = replyNode.continuations[0].nextContinuationData.continuation
+        object.replyToken = continuation
+      }
+
+      comments.push(object)
     })
 
     return comments
-  }
-
-  static parseReplies(nodes) {
-    const replies = []
-
-    nodes.forEach((node) => {
-      const childNodes = this.removeTextNodes(node.childNodes)
-      const commentObject = this.parseComment(childNodes)
-      replies.push(commentObject)
-    })
-
-    return replies
-  }
-
-  static parseComment(node) {
-    const comment = {}
-    const channelImageNode = this.removeTextNodes(node[0].childNodes)
-    const contentNodes = this.removeTextNodes(node[1].childNodes)
-    const channelNodes = this.removeTextNodes(contentNodes[0].childNodes)
-    const channelNameNode = channelNodes[0]
-    const timeNode = channelNodes[3] ? channelNodes[3] : channelNodes[2]
-    const commentNode = this.removeTextNodes(contentNodes[1].childNodes)
-    let metaDataNode = this.removeTextNodes(contentNodes[2].childNodes)
-    metaDataNode = this.removeTextNodes(metaDataNode[0].childNodes)
-    const likesNode = metaDataNode[2]
-    const heartsNode = metaDataNode[4]
-    comment.authorThumb = channelImageNode[0].attributes.src
-    comment.author = channelNameNode.innerText
-    comment.id = channelNameNode.attributes.href.replace(/\/(channel|user)\//, '')
-    comment.text = commentNode[0].innerText
-    comment.likes = likesNode.innerText ? parseInt(likesNode.innerText) : 0
-    comment.isHearted = heartsNode ? heartsNode.outerHTML.includes('data-action-on') : false
-    comment.time = timeNode.innerText.trim().replace(/\(edited\)/, '')
-    comment.edited = timeNode.innerText.includes('edited')
-
-    return comment
-  }
-
-  static removeTextNodes(data) {
-    return data.filter((node) => {
-      return typeof node.classNames !== 'undefined'
-    })
   }
 }
 


### PR DESCRIPTION
This PR updates to the new comments API. A few changes were needed for this update.

- The calls to YouTube have been updated to their new endpoints
- Channel thumbnails are now returned as an array instead of one URL
- Replies are no longer included in the initial call and must be a separate call. The new `getCommentReplies()` function handles getting replies from a comment and returns 10 comments at a time.
- The `getAllComments` function has been removed.

I've tested all major functions and everything still seems to be working. Feel free to do any more testing as well if you'd like.