### PR TITLE
Fix viewing comments sorted by newest first and for age-restricted videos

### DIFF
--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -26,16 +26,29 @@ class HttpRequester {
           let continuation = html_data.match(/"nextContinuationData":{"continuation":"(.*?)}/)[0]
           continuation = JSON.parse(`{${continuation}}`)
 
-          let serializedShareEntity = html_data.match(/"serializedShareEntity":(.*?)}/)[0]
-          serializedShareEntity = JSON.parse(`{${serializedShareEntity}`)
-
-          let serializedToken = serializedShareEntity.serializedShareEntity.replace(/\w%3D%3D/, '')
-          serializedToken = serializedToken.replace(/C{1}/, '')
-
-          let continuationToken = continuation.nextContinuationData.continuation
+          let continuationToken = continuation.nextContinuationData.continuation  
 
           if (sortBy === 'new') {
-            continuationToken = continuationToken.replace('%3D', '') + `yFSIRI${serializedToken}TABeAIwAA%3D%3D`
+            const letterContinuationList = {
+              Q: "T",
+              w: "z",
+              A: "D"
+            }
+            let serializedToken, letterContinuation
+            try {
+              let serializedShareEntity = html_data.match(/"serializedShareEntity":(.*?)}/)[0]
+              serializedShareEntity = JSON.parse(`{${serializedShareEntity}`)
+              serializedToken = serializedShareEntity.serializedShareEntity.replace(/\w%3D%3D/, '')
+              letterContinuation = serializedShareEntity.serializedShareEntity.replace(/%3D%3D/, '')
+            } catch {
+              let getTranscriptEndpointParams = html_data.match(/"getTranscriptEndpoint":{"params":"(.*?)}/)[0]
+              getTranscriptEndpointParams = JSON.parse(`{${getTranscriptEndpointParams}}`)
+              serializedToken = getTranscriptEndpointParams.getTranscriptEndpoint.params.replace(/\w%3D%3D/, '')
+              letterContinuation = getTranscriptEndpointParams.getTranscriptEndpoint.params.replace(/%3D%3D/, '')
+            }
+            serializedToken = serializedToken.replace(/C{1}/, '')
+            letterContinuation = letterContinuationList[letterContinuation.slice(-1)]
+            continuationToken = continuationToken.replace('%3D', '') + `yFSIRI${serializedToken}${letterContinuation}ABeAIwAA%3D%3D`
           }
 
           // const clickTrackingParams = continuation.nextContinuationData.clickTrackingParams


### PR DESCRIPTION
Hello GilgusMaximus. This is my first PR for a public open source project, so bear with me.

On the current version of FreeTube (0.11.3), I am unable to view comments via local API:

* Sorted by newest first for some videos - `Error: Request failed with status code 500`
* At all for age-restricted videos - `TypeError: Cannot read property 'continuationContents' of undefined`

Knowing that FreeTube uses `yt-comment-scraper` to load comments, I decided to try fixing both bugs here to the best of my ability.

## Fixing comments sorted by newest first

To load newly-sorted comments, the current scraper uses a token based on the `continuationToken` + yFSIRI + the `serializedToken` + TABeAIwAA%3D%3D.

This token works [for some videos](https://www.youtube.com/watch?v=JIxP2fG8EsY), but [not all](https://www.youtube.com/watch?v=kAJAViPWR_8). As it turns out, the needed first letter of the last string of characters differs per video. From my observations, that letter can be **T** (TABeAIwAA%3D%3D), **z** (zABeAIwAA%3D%3D) or **D** (DABeAIwAA%3D%3D).

How exactly do we determine this letter? Turns out the last letter of the `serializedShareEntity` minus %3D%3D is an indicator.

* If that last letter of `serializedShareEntity` is **Q**, the letter is **T**.
* If that last letter of `serializedShareEntity` is **w**, the letter is **z**.
* If that last letter of `serializedShareEntity` is **A**, the letter is **D**.

My proposed fix utilizes these observations to determine the letter to append to the comments token rather than always using **T**.

## Fixing comments from age-restricted videos

Age-restricted videos have no Share button, and thus lack the `serializedShareEntity`.

Thankfully, there's another way to grab the same token from `serializedShareEntity`: `getTranscriptEndpointParams`. Thus, my proposed fix gets the token from `getTranscriptEndpointParams` if `serializedShareEntity` fails.

In addition, I moved all the logic for getting the token to the if newest first block, as this is not necessary when loading top comments.

Note that this fix will NOT work on age-restricted videos sorted by newest first without a transcript (videos without anyone speaking). In this scenario, the token is not accessible through the HTML source and will need further investigation.

---

Let me know what you think of the fixes and if you have any questions. Thank you!